### PR TITLE
use money for addition on line item prices and add currency + localiz…

### DIFF
--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -41,11 +41,11 @@ Spree::OrderContents.class_eval do
   end
 
   def flexi_variants(variant, line_item, product_customizations_values, ad_hoc_option_value_ids)
-      store = Spree::Store.default
       product_customizations_values ||= []
       ad_hoc_option_value_ids ||= []
-      customizations_offset_price = Spree::Money.new(0, currency: store.default_currency)
-      ad_hoc_options_offset_price = Spree::Money.new(0, currency: store.default_currency)
+      currency = line_item.pricing_options.desired_attributes[:currency]
+      customizations_offset_price = Spree::Money.new(0, currency: currency)
+      ad_hoc_options_offset_price = Spree::Money.new(0, currency: currency) 
 
       if product_customizations_values.count > 0
         customizations_offset_price = line_item.add_customizations(product_customizations_values)
@@ -57,8 +57,7 @@ Spree::OrderContents.class_eval do
         ad_hoc_options_offset_price = line_item.add_ad_hoc_option_values(ad_hoc_option_value_ids)
       end
 
-      pricing_options = Spree::Variant::PricingOptions.new({currency: store.default_currency, country_iso: store.cart_tax_country_iso})
-      line_item.price = (variant.price_for(pricing_options) + customizations_offset_price + ad_hoc_options_offset_price).to_d
+      line_item.price = (variant.price_for(line_item.pricing_options) + customizations_offset_price + ad_hoc_options_offset_price).to_d
 
       return line_item
   end

--- a/app/models/spree/order_contents_decorator.rb
+++ b/app/models/spree/order_contents_decorator.rb
@@ -41,10 +41,11 @@ Spree::OrderContents.class_eval do
   end
 
   def flexi_variants(variant, line_item, product_customizations_values, ad_hoc_option_value_ids)
+      store = Spree::Store.default
       product_customizations_values ||= []
       ad_hoc_option_value_ids ||= []
-      customizations_offset_price = 0
-      ad_hoc_options_offset_price = 0
+      customizations_offset_price = Spree::Money.new(0, currency: store.default_currency)
+      ad_hoc_options_offset_price = Spree::Money.new(0, currency: store.default_currency)
 
       if product_customizations_values.count > 0
         customizations_offset_price = line_item.add_customizations(product_customizations_values)
@@ -56,7 +57,8 @@ Spree::OrderContents.class_eval do
         ad_hoc_options_offset_price = line_item.add_ad_hoc_option_values(ad_hoc_option_value_ids)
       end
 
-      line_item.price = variant.price_in(order.currency).amount + customizations_offset_price + ad_hoc_options_offset_price
+      pricing_options = Spree::Variant::PricingOptions.new({currency: store.default_currency, country_iso: store.cart_tax_country_iso})
+      line_item.price = (variant.price_for(pricing_options) + customizations_offset_price + ad_hoc_options_offset_price).to_d
 
       return line_item
   end


### PR DESCRIPTION
Takes into account store currency and moves everything over to money attributes when adding/subtracting. It also removes deprecated `price_in` method.